### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -229,6 +229,7 @@ function decode(buffer) {
       break;
     }
     pos = next;
+    if (pos%2) pos +=1;
   }
 }
 


### PR DESCRIPTION
From https://sites.google.com/site/musicgapi/technical-documents/wav-file-format.


> One tricky thing about RIFF file chunks is that they must be word aligned. This means that their total size must be a multiple of 2 bytes (ie. 2, 4, 6, 8, and so on). If a chunk contains an odd number of data bytes, causing it not to be word aligned, an extra padding byte with a value of zero must follow the last data byte. This extra padding byte is not counted in the chunk size,  therefor a program must always word align a chunk headers size value in order to calculate the offset of the following chunk.